### PR TITLE
Use dict literal syntax for defining parser return value

### DIFF
--- a/gcn_classic_to_json/notices/SWIFT_BAT_GRB_POS_ACK/__init__.py
+++ b/gcn_classic_to_json/notices/SWIFT_BAT_GRB_POS_ACK/__init__.py
@@ -6,13 +6,13 @@ TJD0 = (2440000, 0.5)
 
 
 def parse(bin):
-    return dict(
-        trigger_time=Time(
+    return {
+        "trigger_time": Time(
             bin[5] + TJD0[0],
             bin[6] / 8640000 + TJD0[1],
             format="jd",
         ).isot,
-        ra=1e-4 * bin[7],
-        dec=1e-4 * bin[8],
-        ra_dec_error=1e-4 * bin[11],
-    )
+        "ra": 1e-4 * bin[7],
+        "dec": 1e-4 * bin[8],
+        "ra_dec_error": 1e-4 * bin[11],
+    }


### PR DESCRIPTION
The `dict(key=value)` syntax makes it inconvenient to define keys like `$schema`, which is not a valid Python keyword argument name.