### PR TITLE
Dump then load notice output to convert Numpy to native types

### DIFF
--- a/gcn_classic_to_json/test/test_notices.py
+++ b/gcn_classic_to_json/test/test_notices.py
@@ -1,5 +1,5 @@
 import importlib.resources
-from json import load
+from json import load, loads
 
 import numpy as np
 import pytest
@@ -52,11 +52,12 @@ def test_notices(key, generate):
     json_path = files / key / "example.json"
 
     value = bin_path.read_bytes()
-    actual = notices.parse(key, value)
+    actual_str = dumps(notices.parse(key, value), indent=2)
+    actual = loads(actual_str)
 
     if generate:
         with json_path.open("w") as f:
-            print(dumps(actual, indent=2), file=f)
+            print(actual_str, file=f)
         pytest.skip(f"saved expected output to {json_path}")
 
     with json_path.open("r") as f:


### PR DESCRIPTION
The check `assert actual == expected` will fail if the `actual` data structure contains Numpy arrays. The exception reads, `ValueError: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all()`.

Dump the notice to JSON and then load it again to convert all Numpy arrays to native data types so that we can rely on Python's built-in deep equality check for dicts and lists.