### PR TITLE
GECAM_FLT and GECAM_GND conversions

### DIFF
--- a/gcn_classic_to_json/notices/GECAM_FLT/__init__.py
+++ b/gcn_classic_to_json/notices/GECAM_FLT/__init__.py
@@ -1,0 +1,39 @@
+from ... import utils
+
+
+def parse(bin):
+    bin[15]  # Unused. According to docs: '4 bytes for the future'
+    bin[27:39]  # Unused. According to docs: '32 bytes for the future'
+    bin[
+        11
+    ]  # Temporarily Unused. Should have a int->class_type mapping but incomplete documentation
+    bin[
+        18
+    ]  # Temporarily Unused. Should have a bit->flag mapping but incomplete documenation
+    bin[21]  # Temporarily Unused. How is it different from burst_dur?
+    bin[22:24]  # Unused. Equivalent to rate_energy_range
+    bin[
+        26
+    ]  # Temporarily Unused. Presumably which detectors activated but incomplete documenation
+    return {
+        "mission": "GECAM",
+        "id": [bin[4]],
+        "messenger": "EM",
+        "mission_type": chr(bin[19] + 64),  # mission type is A or B
+        # There is an error here; You are supposed to divide by 8640000 to get the correct value
+        # But it only seems to work if you divide by 864000000; I'm assuming it's some error in encoding the packets
+        "trigger_time": utils.datetime_to_iso8601(bin[5], bin[6] * 1e-2),
+        "trigger_type": "rate",
+        "rate_energy_range": [bin[24], bin[25]],
+        "rate_snr": bin[20] * 1e-2,
+        "net_count_rate": int(bin[9]),
+        "rate_duration": bin[14] * 1e-4,
+        "ra": bin[7] * 1e-4,
+        "dec": bin[8] * 1e-4,
+        "ra_dec_error": bin[10] * 1e-4,
+        "containment_probability": 0.68,
+        "instrument_phi": bin[12] * 1e-2,
+        "instrument_theta": bin[13] * 1e-2,
+        "latitude": bin[16] * 1e-2,
+        "longitude": bin[17] * 1e-2,
+    }

--- a/gcn_classic_to_json/notices/GECAM_FLT/example.json
+++ b/gcn_classic_to_json/notices/GECAM_FLT/example.json
@@ -1,0 +1,25 @@
+{
+  "mission": "GECAM",
+  "id": [
+    368
+  ],
+  "messenger": "EM",
+  "mission_type": "B",
+  "trigger_time": "2024-05-17T13:01:22.550Z",
+  "trigger_type": "rate",
+  "rate_energy_range": [
+    30,
+    140
+  ],
+  "rate_snr": 5.09,
+  "net_count_rate": 550,
+  "rate_duration": 10.0,
+  "ra": 57.830000000000005,
+  "dec": 17.400000000000002,
+  "ra_dec_error": 1.4899,
+  "containment_probability": 0.68,
+  "instrument_phi": 7.46,
+  "instrument_theta": 51.27,
+  "latitude": 11.09,
+  "longitude": -8.55
+}

--- a/gcn_classic_to_json/notices/GECAM_GND/__init__.py
+++ b/gcn_classic_to_json/notices/GECAM_GND/__init__.py
@@ -1,0 +1,32 @@
+from ... import utils
+
+
+def parse(bin):
+    bin[15]  # Unused. According to docs: '4 bytes for the future'
+    bin[20:39]  # Unused. According to docs: '76 bytes for the future'
+    bin[
+        11
+    ]  # Temporarily Unused. Should have a int->class_type mapping but incomplete documentation
+    bin[
+        18
+    ]  # Temporarily Unused. Should have a bit->flag mapping but incomplete documenation
+    return {
+        "mission": "GECAM",
+        "id": [bin[4]],
+        "messenger": "EM",
+        "mission_type": chr(bin[19] + 64),
+        # There is an error here; You are supposed to divide by 8640000 to get the correct value
+        # But it only seems to work if you divide by 864000000; I'm assuming it's some error in encoding the packets
+        "trigger_time": utils.datetime_to_iso8601(bin[5], bin[6] * 1e-2),
+        "trigger_type": "rate",
+        "net_count_rate": bin[9],
+        "rate_duration": bin[14] * 1e-4,
+        "ra": bin[7] * 1e-4,
+        "dec": bin[8] * 1e-4,
+        "ra_dec_error": bin[10] * 1e-4,
+        "containment_probability": 0.68,
+        "instrument_phi": bin[12] * 1e-2,
+        "instrument_theta": bin[13] * 1e-2,
+        "latitude": bin[16] * 1e-2,
+        "longitude": bin[17] * 1e-2,
+    }

--- a/gcn_classic_to_json/notices/GECAM_GND/example.json
+++ b/gcn_classic_to_json/notices/GECAM_GND/example.json
@@ -1,0 +1,20 @@
+{
+  "mission": "GECAM",
+  "id": [
+    368
+  ],
+  "messenger": "EM",
+  "mission_type": "B",
+  "trigger_time": "2024-05-17T13:01:22.550Z",
+  "trigger_type": "rate",
+  "net_count_rate": 1306,
+  "rate_duration": 27.0,
+  "ra": 56.25,
+  "dec": 16.21,
+  "ra_dec_error": 1.57,
+  "containment_probability": 0.68,
+  "instrument_phi": 5.98,
+  "instrument_theta": 52.83,
+  "latitude": 11.09,
+  "longitude": -8.55
+}


### PR DESCRIPTION
Conversion is not finished as there is incomplete documentation for binary packets.
Additionally, there seems to be an incorrect encoding for trig_sod as it needs to be divided by an another factor of 100 to get the correct datetime.
