### PR TITLE
MAXI_TEST and MAXI_UNKNOWN conversions

### DIFF
--- a/gcn_classic_to_json/notices/MAXI_TEST/__init__.py
+++ b/gcn_classic_to_json/notices/MAXI_TEST/__init__.py
@@ -2,71 +2,72 @@ import numpy as np
 
 from ... import utils
 
-# Will have to rename schema after the location is decided
-# trigger number has wierd things that have to be worked out
-# energy does not accurately work
-# DDDd in tjd, but if the first digits are 0 pad it out
+time_options = [
+    "undefined/unavailable",
+    "1 sec",
+    "3 sec",
+    "10 sec",
+    "30 sec",
+    "1 scan",
+    "1 orbit",
+    "4 orbit",
+    "1 day",
+]
+
+energy_range_options = ["undefined/unavailable", [2, 4], [4, 10], [10, 20], [2, 10]]
+
+# unit in data is in unit mCrabs; need to be converted into erg/cm^2/sec^-1
+# Conversion factors are from Kawamuro et. al. (2018)
+conversion_factors = [4e-12, 1.24e-11, 1.65e-11, 8.74e-12]
 
 
-def parse(bin_arr):
-    # Define all time and energy range values as a list
-    # the index coreesponds to the integer value associated with that time/energy range
-    time_options = [
-        "undefined/unavailable",
-        "1 sec",
-        "3 sec",
-        "10 sec",
-        "30 sec",
-        "1 scan",
-        "1 orbit",
-        "4 orbit",
-        "1 day",
-    ]
-    energy_range_options = ["undefined/unavailable", [2, 4], [4, 10], [10, 20], [2, 10]]
-    # Time and energy_range are encoded in the same 4-btye integer
-    # Energy is the first byte and time is the energy is the second byte
-    t_and_e_data = np.flip(bin_arr[15:16].view(dtype="i1"))
-    time_opt, e_opt = t_and_e_data[0], t_and_e_data[1]
-    # unit in data is in unit mCrabs; need to be converted into erg/cm^2/sec^-1
-    # Conversion factors are from Kawamuro et. al. (2018)
-    conversion_factors = [4e-12, 1.24e-11, 1.65e-11, 8.74e-12]
-    # Similarly, Latitude is the last 2 bytes and longitude is the first 2 in the same int
-    latitude_longitude_data = np.flip(bin_arr[16:17].view(dtype=">i2"))
-    lat, lon = latitude_longitude_data[1], latitude_longitude_data[0]
-    output = {
-        # "$schema" : "",
-        "mission": "MAXI",
-        # "alert_type" : "initial", # value cannot be calculated with packets
-        # "record_number" : 0, # value cannot be calculated with packets
-        "id": [int(bin_arr[4])],
-        "trigger_time": utils.tjd_to_jd(bin_arr[5], bin_arr[6]),
-        "messenger": "EM",
-        "flux_energy_range": energy_range_options[e_opt],
-        "duration": time_options[time_opt],
-        "ra": bin_arr[7] * 1e-4,
-        "dec": bin_arr[8] * 1e-4,
-        "ra_dec_error": bin_arr[11] * 1e-4,
-        "systematic_included": True,
-        "latitude": lat * 1e-2,
-        "longitude": lon * 1e-2,
-    }
-    # add energy range if available
-    if e_opt != 0:
-        # -1 since there is no conversion associated with "undefined/unavailable"
-        output["energy_flux"] = bin_arr[9] * 0.1 * conversion_factors[e_opt - 1]
+def parse(bin):
+    bin[
+        4
+    ]  # Temporarily Unused. According to source code: 'Trigger ID number (only partial of the full MAXI ID number)'
+    bin[10]  # Spare. According to Docs: '4 bytes for future use'.
+    bin[17]  # Spare. According to Docs: '4 bytes for future use'.
+    bin[20:39]  # Spare. According to Docs: '76 bytes for future use'.
 
-    event_flag_bits = np.flip(np.unpackbits(bin_arr[18:19].view(dtype="u1")))
+    source_low, bkg_low = np.flip(bin[12:13].view(dtype=">i2"))
+    source_medium, bkg_medium = np.flip(bin[13:14].view(dtype=">i2"))
+    source_high, bkg_high = np.flip(bin[14:15].view(dtype=">i2"))
+
+    time_opt, e_opt, _, _ = np.flip(bin[15:16].view(dtype="i1"))
+
+    lon, lat = np.flip(bin[16:17].view(dtype=">i2"))
+
+    event_flag_bits = np.flip(np.unpackbits(bin[18:19].view(dtype="u1")))
 
     comments = ""
     if event_flag_bits[4] == 1:
         comments += "This notice contains negative flux.\n"
 
-    misc_bits = np.flip(np.unpackbits(bin_arr[19:20].view(dtype="u1")))
+    misc_bits = np.flip(np.unpackbits(bin[19:20].view(dtype="u1")))
 
     if misc_bits[30] == 1:
-        comments += "This notice was ground-generated.\n"
+        comments += "This notice was ground-generated."
 
-    if comments:
-        output["additional_info"] = comments
-
-    return output
+    return {
+        "mission": "MAXI",
+        "trigger_time": utils.datetime_to_iso8601(bin[5], bin[6]),
+        "messenger": "EM",
+        "flux_energy_range": energy_range_options[e_opt],
+        "duration": time_options[time_opt],
+        "ra": bin[7] * 1e-4,
+        "dec": bin[8] * 1e-4,
+        "ra_dec_error": bin[11] * 1e-4,
+        "source_flux_low_band": source_low * 0.1,
+        "background_flux_low_band": bkg_low * 0.1,
+        "source_flux_medium_band": source_medium * 0.1,
+        "background_flux_medium_band": bkg_medium * 0.1,
+        "source_flux_high_band": source_high * 0.1,
+        "background_flux_high_band": bkg_high * 0.1,
+        "systematic_included": True,
+        "latitude": lat * 1e-2,
+        "longitude": lon * 1e-2,
+        "energy_flux": (
+            bin[9] * 0.1 * conversion_factors[e_opt - 1] if e_opt != 0 else None
+        ),
+        "additional_info": comments if comments else None,
+    }

--- a/gcn_classic_to_json/notices/MAXI_TEST/__init__.py
+++ b/gcn_classic_to_json/notices/MAXI_TEST/__init__.py
@@ -1,0 +1,72 @@
+import numpy as np
+
+from ... import utils
+
+# Will have to rename schema after the location is decided
+# trigger number has wierd things that have to be worked out
+# energy does not accurately work
+# DDDd in tjd, but if the first digits are 0 pad it out
+
+
+def parse(bin_arr):
+    # Define all time and energy range values as a list
+    # the index coreesponds to the integer value associated with that time/energy range
+    time_options = [
+        "undefined/unavailable",
+        "1 sec",
+        "3 sec",
+        "10 sec",
+        "30 sec",
+        "1 scan",
+        "1 orbit",
+        "4 orbit",
+        "1 day",
+    ]
+    energy_range_options = ["undefined/unavailable", [2, 4], [4, 10], [10, 20], [2, 10]]
+    # Time and energy_range are encoded in the same 4-btye integer
+    # Energy is the first byte and time is the energy is the second byte
+    t_and_e_data = np.flip(bin_arr[15:16].view(dtype="i1"))
+    time_opt, e_opt = t_and_e_data[0], t_and_e_data[1]
+    # unit in data is in unit mCrabs; need to be converted into erg/cm^2/sec^-1
+    # Conversion factors are from Kawamuro et. al. (2018)
+    conversion_factors = [4e-12, 1.24e-11, 1.65e-11, 8.74e-12]
+    # Similarly, Latitude is the last 2 bytes and longitude is the first 2 in the same int
+    latitude_longitude_data = np.flip(bin_arr[16:17].view(dtype=">i2"))
+    lat, lon = latitude_longitude_data[1], latitude_longitude_data[0]
+    output = {
+        # "$schema" : "",
+        "mission": "MAXI",
+        # "alert_type" : "initial", # value cannot be calculated with packets
+        # "record_number" : 0, # value cannot be calculated with packets
+        "id": [int(bin_arr[4])],
+        "trigger_time": utils.tjd_to_jd(bin_arr[5], bin_arr[6]),
+        "messenger": "EM",
+        "flux_energy_range": energy_range_options[e_opt],
+        "duration": time_options[time_opt],
+        "ra": bin_arr[7] * 1e-4,
+        "dec": bin_arr[8] * 1e-4,
+        "ra_dec_error": bin_arr[11] * 1e-4,
+        "systematic_included": True,
+        "latitude": lat * 1e-2,
+        "longitude": lon * 1e-2,
+    }
+    # add energy range if available
+    if e_opt != 0:
+        # -1 since there is no conversion associated with "undefined/unavailable"
+        output["energy_flux"] = bin_arr[9] * 0.1 * conversion_factors[e_opt - 1]
+
+    event_flag_bits = np.flip(np.unpackbits(bin_arr[18:19].view(dtype="u1")))
+
+    comments = ""
+    if event_flag_bits[4] == 1:
+        comments += "This notice contains negative flux.\n"
+
+    misc_bits = np.flip(np.unpackbits(bin_arr[19:20].view(dtype="u1")))
+
+    if misc_bits[30] == 1:
+        comments += "This notice was ground-generated.\n"
+
+    if comments:
+        output["additional_info"] = comments
+
+    return output

--- a/gcn_classic_to_json/notices/MAXI_TEST/example.json
+++ b/gcn_classic_to_json/notices/MAXI_TEST/example.json
@@ -1,0 +1,24 @@
+{
+  "mission": "MAXI",
+  "trigger_time": "2024-05-11T17:07:17.000Z",
+  "messenger": "EM",
+  "flux_energy_range": [
+    2,
+    4
+  ],
+  "duration": "30 sec",
+  "ra": 252.0,
+  "dec": 35.0,
+  "ra_dec_error": 1.0,
+  "source_flux_low_band": 0.0,
+  "background_flux_low_band": 0.0,
+  "source_flux_medium_band": 0.0,
+  "background_flux_medium_band": 0.0,
+  "source_flux_high_band": 0.0,
+  "background_flux_high_band": 0.0,
+  "systematic_included": true,
+  "latitude": -33.33,
+  "longitude": 123.45,
+  "energy_flux": 1.592e-10,
+  "additional_info": "This notice was ground-generated."
+}

--- a/gcn_classic_to_json/notices/MAXI_UNKNOWN/__init__.py
+++ b/gcn_classic_to_json/notices/MAXI_UNKNOWN/__init__.py
@@ -1,0 +1,67 @@
+import numpy as np
+
+from ... import utils
+
+# Will have to rename schema after the location is decided
+# trigger number has wierd things that have to be worked out
+# energy does not accurately work
+# trigger number has wierd things that have to be worked out
+
+
+def parse(bin_arr):
+    # Time and energy range are encoded in the same int
+    # Define all time and energy range values as a list
+    time_options = [
+        "undefined/unavailable",
+        "1 sec",
+        "3 sec",
+        "10 sec",
+        "30 sec",
+        "1 scan",
+        "1 orbit",
+        "4 orbit",
+        "1 day",
+    ]
+    energy_range_options = ["undefined/unavailable", [2, 4], [4, 10], [10, 20], [2, 10]]
+    # unit in data is in unit mCrabs; need to be converted into erg/cm^2/sec^-1
+    # Conversion factors are from Kawamuro et. al. (2018)
+    conversion_factors = [4e-12, 1.24e-11, 1.65e-11, 8.74e-12]
+    time_and_energy_data = np.flip(bin_arr[15:16].view(dtype="i1"))
+    # Time is encoded in the 1st byte and energy_range is encoded in the 2nd
+    time_opt, e_opt = time_and_energy_data[0], time_and_energy_data[1]
+    output = {
+        "$schema": "",
+        "mission": "MAXI",
+        "alert_type": str(bin(bin_arr[15])),
+        "id": [int(bin_arr[4])],
+        "messenger": "EM",
+        "trigger_time": utils.tjd_to_jd(bin_arr[5], bin_arr[6]),
+        "flux_energy_range": energy_range_options[e_opt],
+        "duration": time_options[time_opt],
+        "ra": float(bin_arr[7]) * 1e-4,
+        "dec": float(bin_arr[8]) * 1e-4,
+        "ra_dec_error": float(bin_arr[11]) * 1e-4,
+        "systematic_included": True,
+    }
+
+    # add energy range if available
+    if e_opt != 0:
+        # -1 since there is no conversion associated with "undefined/unavailable"
+        output["energy_flux"] = bin_arr[9] * 0.1 * conversion_factors[e_opt - 1]
+        output["energy_flux_error"] = bin_arr[10] * 0.1 * conversion_factors[e_opt - 1]
+
+    event_flag_bits = np.flip(np.unpackbits(bin_arr[18:19].view(dtype="u1")))
+
+    comments = ""
+    if event_flag_bits[4] == 1:
+        comments += "This notice contains negative flux.\n"
+
+    misc_bits = np.flip(np.unpackbits(bin_arr[19:20].view(dtype="u1")))
+
+    if misc_bits[30] == 1:
+        comments += "This notice was ground-generated.\n"
+
+    if comments:
+        output["additional_info"] = comments
+
+    return output

--- a/gcn_classic_to_json/notices/MAXI_UNKNOWN/__init__.py
+++ b/gcn_classic_to_json/notices/MAXI_UNKNOWN/__init__.py
@@ -2,66 +2,65 @@ import numpy as np
 
 from ... import utils
 
-# Will have to rename schema after the location is decided
-# trigger number has wierd things that have to be worked out
-# energy does not accurately work
-# trigger number has wierd things that have to be worked out
+time_options = [
+    "undefined/unavailable",
+    "1 sec",
+    "3 sec",
+    "10 sec",
+    "30 sec",
+    "1 scan",
+    "1 orbit",
+    "4 orbit",
+    "1 day",
+]
+
+energy_range_options = ["undefined/unavailable", [2, 4], [4, 10], [10, 20], [2, 10]]
+
+# unit in data is in unit mCrabs; need to be converted into erg/cm^2/sec^-1
+# Conversion factors are from Kawamuro et. al. (2018)
+conversion_factors = [4e-12, 1.24e-11, 1.65e-11, 8.74e-12]
 
 
-def parse(bin_arr):
-    # Time and energy range are encoded in the same int
-    # Define all time and energy range values as a list
-    time_options = [
-        "undefined/unavailable",
-        "1 sec",
-        "3 sec",
-        "10 sec",
-        "30 sec",
-        "1 scan",
-        "1 orbit",
-        "4 orbit",
-        "1 day",
-    ]
-    energy_range_options = ["undefined/unavailable", [2, 4], [4, 10], [10, 20], [2, 10]]
-    # unit in data is in unit mCrabs; need to be converted into erg/cm^2/sec^-1
-    # Conversion factors are from Kawamuro et. al. (2018)
-    conversion_factors = [4e-12, 1.24e-11, 1.65e-11, 8.74e-12]
-    time_and_energy_data = np.flip(bin_arr[15:16].view(dtype="i1"))
-    # Time is encoded in the 1st byte and energy_range is encoded in the 2nd
-    time_opt, e_opt = time_and_energy_data[0], time_and_energy_data[1]
-    output = {
-        "$schema": "",
-        "mission": "MAXI",
-        "alert_type": str(bin(bin_arr[15])),
-        "id": [int(bin_arr[4])],
-        "messenger": "EM",
-        "trigger_time": utils.tjd_to_jd(bin_arr[5], bin_arr[6]),
-        "flux_energy_range": energy_range_options[e_opt],
-        "duration": time_options[time_opt],
-        "ra": float(bin_arr[7]) * 1e-4,
-        "dec": float(bin_arr[8]) * 1e-4,
-        "ra_dec_error": float(bin_arr[11]) * 1e-4,
-        "systematic_included": True,
-    }
+def parse(bin):
+    bin[
+        4
+    ]  # Temporarily Unused. According to source code: 'Trigger ID number (only partial of the full MAXI ID number)'
+    bin[
+        12:15
+    ]  # Spare. According to docs: 'As of 31Aug2011, the MAXI Team stopped giving these value for the Unknown Transients'
+    bin[
+        16:18
+    ]  # Spare. According to docs: 'As of 31Aug2011, the MAXI Team stopped giving these Lon,Lat values for the Unknown Transients'
+    bin[20:39]  # Spare. According to docs: '76 bytes for future use'
 
-    # add energy range if available
-    if e_opt != 0:
-        # -1 since there is no conversion associated with "undefined/unavailable"
-        output["energy_flux"] = bin_arr[9] * 0.1 * conversion_factors[e_opt - 1]
-        output["energy_flux_error"] = bin_arr[10] * 0.1 * conversion_factors[e_opt - 1]
+    time_opt, e_opt, _, _ = np.flip(bin[15:16].view(dtype="i1"))
 
-    event_flag_bits = np.flip(np.unpackbits(bin_arr[18:19].view(dtype="u1")))
+    event_flag_bits = np.flip(np.unpackbits(bin[18:19].view(dtype="u1")))
 
     comments = ""
     if event_flag_bits[4] == 1:
         comments += "This notice contains negative flux.\n"
 
-    misc_bits = np.flip(np.unpackbits(bin_arr[19:20].view(dtype="u1")))
+    misc_bits = np.flip(np.unpackbits(bin[19:20].view(dtype="u1")))
 
     if misc_bits[30] == 1:
         comments += "This notice was ground-generated.\n"
 
-    if comments:
-        output["additional_info"] = comments
-
-    return output
+    return {
+        "mission": "MAXI",
+        "messenger": "EM",
+        "trigger_time": utils.datetime_to_iso8601(bin[5], bin[6]),
+        "flux_energy_range": energy_range_options[e_opt],
+        "duration": time_options[time_opt],
+        "ra": bin[7] * 1e-4,
+        "dec": bin[8] * 1e-4,
+        "ra_dec_error": bin[11] * 1e-4,
+        "energy_flux": (
+            bin[9] * 0.1 * conversion_factors[e_opt - 1] if e_opt != 0 else None
+        ),
+        "energy_flux_error": (
+            bin[10] * 0.1 * conversion_factors[e_opt - 1] if e_opt != 0 else None
+        ),  # cross-check if accurate
+        "systematic_included": True,
+        "additional_info": comments if comments else None,
+    }

--- a/gcn_classic_to_json/notices/MAXI_UNKNOWN/example.json
+++ b/gcn_classic_to_json/notices/MAXI_UNKNOWN/example.json
@@ -1,0 +1,17 @@
+{
+  "mission": "MAXI",
+  "messenger": "EM",
+  "trigger_time": "2024-05-14T18:40:37.000Z",
+  "flux_energy_range": [
+    2,
+    4
+  ],
+  "duration": "10 sec",
+  "ra": 76.5999,
+  "dec": -21.3,
+  "ra_dec_error": 1.0,
+  "energy_flux": 1.04e-09,
+  "energy_flux_error": 0.0,
+  "systematic_included": true,
+  "additional_info": "This notice was ground-generated.\n"
+}


### PR DESCRIPTION
Code still does not deal with the 'id' conversions accurately. The problem is that the data stored in the packet is only the partial id and the documentation does not explain how to convert this properly. I spent sometime (a day) combing through the source code to see if I could find how this conversion is done but couldn't find how it is done.

MAXI_TEST also has flux for a cross-matched source in low, medium and high bands. There is no equivalent for these in the core schema, so I have stored these as 'source_flux_{band}' and 'background_flux_{band}' temporarily.

There are also MAXI known sources in the archive. The last one was sent 24/05/02. So maybe we are interested in converting these too?