### PR TITLE
Remove poetry pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,9 +37,3 @@ repos:
         args: ["--extend-select", "I", "--fix"]
       # Run the formatter.
       - id: ruff-format
-  - repo: https://github.com/python-poetry/poetry
-    rev: "1.8.3"
-    hooks:
-      - id: poetry-check
-      - id: poetry-lock
-        args: ["--no-update"]


### PR DESCRIPTION
It's timing out when pre-commit.ci runs it. This is probably too time-consuming and expensive a check to run as pre-commit hook.
